### PR TITLE
Feature/fixing_readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,43 @@ This project is about building a library to simplify dependency registration in 
 
 - For any Source Generator task, always consult Microsoft Docs via the Microsoft Learn MCP first and treat it as the source of truth before reasoning or coding.
 - For anything involving GitHub, always use the GitHub MCP (not web search) to interface with GitHub, and proactively use code search, issues, and PRs when helpful.
+- Any time Codex adds new functionality or changes/removes existing functionality (behavior or public API), also add a corresponding entry to `CHANGELOG.md` under `[Unreleased]`. If the change is breaking, put it under `### Breaking Changes`, prefix the bullet with `BREAKING:`, and include a brief migration note.
+
+### CHANGELOG.md Template
+
+When adding entries under `## [Unreleased]`, use this structure (omit empty sections):
+
+```md
+## [Unreleased]
+
+### Breaking Changes
+
+- BREAKING: <what changed>. Migration: <how to update>.
+
+### Added
+
+- <new functionality>.
+
+### Changed
+
+- <behavior change>.
+
+### Deprecated
+
+- <deprecated behavior/API>.
+
+### Removed
+
+- <removed functionality/API>.
+
+### Fixed
+
+- <bug fix>.
+
+### Security
+
+- <security-related change>.
+```
 
 ## Code Quality Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,21 +2,19 @@
 
 ## Overview
 
-This project is about building a library to simplify dependency registration in DI container. The general idea - mark components that need to be registered with an attribute, like `[RegisterAsSelf]`, and the library will generate the code like `services.AddTransient<MyService>()` to automatically register and wire all of the components. Heavily uses .NET source generators to avoid reflection scan at runtime.
+Library that uses .NET source generators to turn attributes (e.g. `[RegisterAsSelf]`) into DI registrations (e.g. `services.AddTransient<MyService>()`) without runtime reflection scanning.
 
 ## General Guidelines
 
-- For any Source Generator task, always consult Microsoft Docs via the Microsoft Learn MCP first and treat it as the source of truth before reasoning or coding.
-- For anything involving GitHub, always use the GitHub MCP (not web search) to interface with GitHub, and proactively use code search, issues, and PRs when helpful.
-- Any time Codex adds new functionality or changes/removes existing functionality (behavior or public API), also add a corresponding entry to `CHANGELOG.md` under `[Unreleased]`. If the change is breaking, put it under `### Breaking Changes`, prefix the bullet with `BREAKING:`, and include a brief migration note.
+- Source generators: consult Microsoft Learn MCP first (source of truth) any time working with source generators.
+- GitHub work: use the GitHub MCP (not web search).
+- Functional changes (new/changed/removed behavior or public API): add an entry to `CHANGELOG.md` under `[Unreleased]` using the template below. Breaking changes go under `### Breaking Changes`, start with `BREAKING:`, and include a brief migration note.
 
 ### CHANGELOG.md Template
 
-When adding entries under `## [Unreleased]`, use this structure (omit empty sections):
+Under `## [Unreleased]`, use this structure (omit empty sections):
 
 ```md
-## [Unreleased]
-
 ### Breaking Changes
 
 - BREAKING: <what changed>. Migration: <how to update>.
@@ -48,20 +46,17 @@ When adding entries under `## [Unreleased]`, use this structure (omit empty sect
 
 ## Code Quality Guidelines
 
-- Make sure code is maintainable and easy to understand. Suggest refactoring when beneficial.
-- If refactoring is challenging, complicated, or the user explicitly declined, add strategic comments to improve maintainability instead.
-- Do not overuse comments; place them only where they add real value.
-- Minimize public surface area: Use `private` or `internal` access modifiers by default unless the API is intentionally designed to be public. A smaller public API is easier to maintain and reduces breaking change concerns in future versions.
+- Prefer maintainable, easy-to-read code; refactor when it helps.
+- If refactoring is too costly or declined, add small, high-value comments (don't over-comment).
+- Minimize public surface area: prefer `internal`/`private` unless intentionally public API.
 
 ## Public API Documentation
 
-This is a library. **All** public methods, properties, classes, and interfaces in library code **must** have XML documentation (///).
+Library projects require XML docs (`///`) on all public APIs:
 
-This requirement applies to library code only (`src/AttributedDI/`, `src/AttributedDI.SourceGenerator/`). Test projects are exempt.
-
-Document only public APIs in library projects
-
-Update documentation when signatures change
+- Applies to `src/AttributedDI/` and `src/AttributedDI.SourceGenerator/`.
+- Test projects are exempt.
+- Update docs when signatures change.
 
 ### Example
 
@@ -72,8 +67,3 @@ Update documentation when signatures change
 /// <exception cref="ArgumentNullException">Thrown when parameters are null.</exception>
 public void RegisterService(Type serviceType, Type implementationType)
 ```
-
-### Documentation Rules
-
-- Document only public APIs in library projects
-- Update documentation when signatures change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Updated the README to clarify that `[GenerateInterface]` and `[RegisterAsGeneratedInterface]` require non‑nested partial classes or structs.
+
 ## [1.0.0] - 2026-01-27
 
 - Attribute-driven registrations (`RegisterAsSelf`, `RegisterAsImplementedInterfaces`, `RegisterAs<TService>`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,3 @@ All notable changes to this project will be documented in this file.
 - Custom generated extension naming via `ServiceCollectionExtension`.
 - Aggregate `AddAttributedDi()` generation across referenced projects (opt-in MSBuild property).
 - Source-generated registration code (no runtime reflection scanning).
-

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AttributedDI can also generate an interface for you and register against it in o
 
 ```csharp
 [RegisterAsGeneratedInterface]
-public sealed class MetricsSink
+public sealed partial class MetricsSink
 {
     public void Write(string name, double value) { }
 
@@ -118,7 +118,7 @@ Generate an interface from a concrete type:
 
 ```csharp
 [GenerateInterface]
-public sealed class WeatherClient
+public sealed partial class WeatherClient
 {
     public Task<string> GetAsync(string city, CancellationToken ct) => Task.FromResult("ok");
 }
@@ -128,7 +128,7 @@ Generate an interface and register against it in one step:
 
 ```csharp
 [RegisterAsGeneratedInterface]
-public sealed class MetricsSink
+public sealed partial class MetricsSink
 {
     public void Write(string name, double value) { }
 
@@ -136,6 +136,8 @@ public sealed class MetricsSink
     public string DebugOnly => "local";
 }
 ```
+
+Both `[GenerateInterface]` and `[RegisterAsGeneratedInterface]` require a non-nested `partial` class or struct.
 
 For edge cases and exclusions, see `docs/interface-generation-exceptions.md`.
 

--- a/docs/interface-generation-exceptions.md
+++ b/docs/interface-generation-exceptions.md
@@ -6,6 +6,7 @@ expect.
 
 ## What is generated
 
+- Non-nested `partial` classes or structs are eligible for interface generation.
 - Public instance methods, properties, events, and indexers declared on the type.
 - Generic type parameters and constraints are preserved (including nullability).
 - Optional parameters with default values are preserved.

--- a/src/AttributedDI/GenerateInterfaceAttribute.cs
+++ b/src/AttributedDI/GenerateInterfaceAttribute.cs
@@ -8,6 +8,7 @@ namespace AttributedDI;
 /// <remarks>
 /// <para>Generation contract (supported):</para>
 /// <list type="bullet">
+/// <item><description>Non-nested partial classes or structs.</description></item>
 /// <item><description>Instance members only; no static members or operators are emitted.</description></item>
 /// <item><description>Public methods, properties, events, and indexers declared on the type.</description></item>
 /// <item><description>Declared members only; inherited members are ignored.</description></item>

--- a/src/AttributedDI/RegisterAsGeneratedInterfaceAttribute.cs
+++ b/src/AttributedDI/RegisterAsGeneratedInterfaceAttribute.cs
@@ -8,6 +8,7 @@ namespace AttributedDI;
 /// <remarks>
 /// <para>Generation contract (supported):</para>
 /// <list type="bullet">
+/// <item><description>Non-nested partial classes or structs.</description></item>
 /// <item><description>Instance members only; no static members or operators are emitted.</description></item>
 /// <item><description>Public methods, properties, events, and indexers declared on the type.</description></item>
 /// <item><description>Declared members only; inherited members are ignored.</description></item>


### PR DESCRIPTION
Make sure readme properly reflects the fact that the class has to be partial for the interface to be successfully generated.